### PR TITLE
PLAT-119858: Fixed SnapshotPlugin to clear ilib cache from dev-utils 2.8.1

### DIFF
--- a/node_modules/@enact/dev-utils/plugins/SnapshotPlugin/snapshot-helper.js
+++ b/node_modules/@enact/dev-utils/plugins/SnapshotPlugin/snapshot-helper.js
@@ -32,6 +32,9 @@ global.updateEnvironment = function() {
 		var ilib = require('ilib/lib/ilib');
 		if (ilib && ilib._load) {
 			ilib._load._cacheValidated = false;
+			if (ilib.clearCache) {
+				ilib.clearCache();
+			}
 		}
 
 		// Clear the active resBundle and string cache.


### PR DESCRIPTION

Enact-DCO-1.0-Signed-off-by: Mikyung Kim (mikyung27.kim@lge.com)